### PR TITLE
Added IPNS publish feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ ipfs-sync --node-addr=multiaddr <directory>
 
 Publish to IPNS
 ```console
-$ ipfs-sync --node-addr=multiaddr --key=QmdZ... <directory>
+$ ipfs-sync --node-addr=multiaddr --ipns-key=QmdZ... <directory>
 ```
 
 You can also specify name of the key. 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ $ go get -u github.com/ipfn/ipfs-sync
 $ ipfs-sync --node-addr=multiaddr <directory>
 ```
 
+Publish to IPNS
+```console
+$ ipfs-sync --node-addr=multiaddr --publish=true --key=QmdZjqVMbATh1YVdbtZA9j9aVkGKUXjM4aCHAT6yGiPY9R <directory>
+```
+
+You can also specify name of the key. 
+```console
+$ ipfs-sync --node-addr=multiaddr --publish=true --key=testKey <directory>
+```
+
+If key is not specified, self key will be used by default. 
+```console
+$ ipfs-sync --node-addr=multiaddr --publish=true <directory>
+```
 ## License
 
                                  Apache License

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ $ ipfs-sync --node-addr=multiaddr <directory>
 
 Publish to IPNS
 ```console
-$ ipfs-sync --node-addr=multiaddr --publish=true --key=QmdZjqVMbATh1YVdbtZA9j9aVkGKUXjM4aCHAT6yGiPY9R <directory>
+$ ipfs-sync --node-addr=multiaddr --key=QmdZ... <directory>
 ```
 
 You can also specify name of the key. 
 ```console
-$ ipfs-sync --node-addr=multiaddr --publish=true --key=testKey <directory>
+$ ipfs-sync --node-addr=multiaddr --ipns-key=testKey <directory>
 ```
 
-If key is not specified, self key will be used by default. 
+You can also specify --key=self to publish to self key of IPNS.
 ```console
-$ ipfs-sync --node-addr=multiaddr --publish=true <directory>
+$ ipfs-sync --node-addr=multiaddr --ipns-key=self <directory>
 ```
 ## License
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ import (
 var (
 	verbose = flag.Bool("verbose", false, "Print logs to stderr")
 	nodeURL = flag.String("node-addr", "/ip4/127.0.0.1/tcp/5001/", "IPFS node URL")
+	publish = flag.Bool("publish", false, "Option to publish to IPNS")
+	key     = flag.String("key", "", "key to publish to publish to IPNS")
 
 	// Ignore .git and .gitignore files by default
 	git = flag.Bool("git", true, "Ignores files from .gitignore and .git directory itself.")
@@ -39,6 +41,9 @@ func main() {
 	}
 
 	path := flag.Arg(0)
+	if *key == "" {
+		*key = "self"
+	}
 	if path == "" {
 		log.Fatal("Usage: ipfs-sync --node-addr=multiaddr <directory>")
 	}
@@ -78,11 +83,28 @@ func main() {
 		log.Fatalf("watch error: %v", err)
 	}
 
-	fmt.Println(snc.Hash())
+	var cmd *exec.Cmd
+	cmd = checkPublish(cmd, snc.Hash(), true)
 
 	for hash := range snc.Events() {
+		cmd = checkPublish(cmd, hash, false)
+	}
+}
+
+func checkPublish(cmd *exec.Cmd, hash string, printLogs bool) *exec.Cmd {
+	var err error
+	if *publish && hash != "" {
+		cmd, err = shell.Publish(cmd, hash, *key)
+		if err != nil {
+			fmt.Printf("Publish error: %s\n", err.Error())
+			os.Exit(1)
+		} else if printLogs {
+			fmt.Printf("Publishing to key %s\n", *key)
+		}
+	} else if !*publish {
 		fmt.Println(hash)
 	}
+	return cmd
 }
 
 type stringList []string

--- a/main.go
+++ b/main.go
@@ -17,8 +17,7 @@ import (
 var (
 	verbose = flag.Bool("verbose", false, "Print logs to stderr")
 	nodeURL = flag.String("node-addr", "/ip4/127.0.0.1/tcp/5001/", "IPFS node URL")
-	publish = flag.Bool("publish", false, "Option to publish to IPNS")
-	key     = flag.String("key", "", "key to publish to publish to IPNS")
+	ipnsKey = flag.String("ipns-key", "", "key to publish to IPNS")
 
 	// Ignore .git and .gitignore files by default
 	git = flag.Bool("git", true, "Ignores files from .gitignore and .git directory itself.")
@@ -41,9 +40,7 @@ func main() {
 	}
 
 	path := flag.Arg(0)
-	if *key == "" {
-		*key = "self"
-	}
+
 	if path == "" {
 		log.Fatal("Usage: ipfs-sync --node-addr=multiaddr <directory>")
 	}
@@ -93,15 +90,15 @@ func main() {
 
 func checkPublish(cmd *exec.Cmd, hash string, printLogs bool) *exec.Cmd {
 	var err error
-	if *publish && hash != "" {
-		cmd, err = shell.Publish(cmd, hash, *key)
+	if *ipnsKey != "" && hash != "" {
+		cmd, err = shell.Publish(cmd, hash, *ipnsKey)
 		if err != nil {
 			fmt.Printf("Publish error: %s\n", err.Error())
 			os.Exit(1)
 		} else if printLogs {
-			fmt.Printf("Publishing to key %s\n", *key)
+			fmt.Printf("Publishing to key %s\n", *ipnsKey)
 		}
-	} else if !*publish {
+	} else if *ipnsKey == "" && hash != "" {
 		fmt.Println(hash)
 	}
 	return cmd

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -78,10 +79,22 @@ func main() {
 		log.Fatalf("watch error: %v", err)
 	}
 
-	hashCh := shell.Publish(*ipnsKey)
-	hashCh <- snc.Hash()
-	for hash := range snc.Events() {
-		hashCh <- hash
+	if *ipnsKey == "" {
+		fmt.Println(snc.Hash())
+		for hash := range snc.Events() {
+			fmt.Println(hash)
+		}
+	} else {
+		hashCh := make(chan string)
+		msg, err := shell.Publish(*ipnsKey, hashCh)
+		if err != nil {
+			log.Fatalf("Publish error: %s\n", err)
+		}
+		fmt.Println(msg)
+		hashCh <- snc.Hash()
+		for hash := range snc.Events() {
+			hashCh <- hash
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -40,7 +39,6 @@ func main() {
 	}
 
 	path := flag.Arg(0)
-
 	if path == "" {
 		log.Fatal("Usage: ipfs-sync --node-addr=multiaddr <directory>")
 	}
@@ -80,28 +78,11 @@ func main() {
 		log.Fatalf("watch error: %v", err)
 	}
 
-	var cmd *exec.Cmd
-	cmd = checkPublish(cmd, snc.Hash(), true)
-
+	hashCh := shell.Publish(*ipnsKey)
+	hashCh <- snc.Hash()
 	for hash := range snc.Events() {
-		cmd = checkPublish(cmd, hash, false)
+		hashCh <- hash
 	}
-}
-
-func checkPublish(cmd *exec.Cmd, hash string, printLogs bool) *exec.Cmd {
-	var err error
-	if *ipnsKey != "" && hash != "" {
-		cmd, err = shell.Publish(cmd, hash, *ipnsKey)
-		if err != nil {
-			fmt.Printf("Publish error: %s\n", err.Error())
-			os.Exit(1)
-		} else if printLogs {
-			fmt.Printf("Publishing to key %s\n", *ipnsKey)
-		}
-	} else if *ipnsKey == "" && hash != "" {
-		fmt.Println(hash)
-	}
-	return cmd
 }
 
 type stringList []string

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"os/exec"
@@ -56,4 +57,38 @@ func RmLink(last, path string) (string, error) {
 // AddLink - Creates link from IPFS object and returns new hash.
 func AddLink(last, path, hash string) (string, error) {
 	return Exec("object", "patch", "add-link", last, path, hash)
+}
+
+func keyExists(key string) bool {
+	keys, err := Exec("key", "list", "-l")
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(keys, "\n")
+	for _, line := range lines {
+		keyNames := strings.Split(line, " ")
+		for _, keyName := range keyNames {
+			if keyName != "" && keyName == key {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Publish - Publishes the ipfs hash to the provided ipns key
+func Publish(cmd *exec.Cmd, hash, key string) (*exec.Cmd, error) {
+	if !keyExists(key) {
+		return nil, errors.New("Key does not exist")
+	}
+	if cmd != nil {
+		cmd.Process.Kill()
+	}
+
+	cmd = exec.Command("ipfs", "name", "publish", hash)
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	go func() { cmd.Wait() }()
+	return cmd, nil
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -64,10 +64,8 @@ func keyExists(key string) bool {
 	if err != nil {
 		return false
 	}
-	lines := strings.Split(keys, "\n")
-	for _, line := range lines {
-		keyNames := strings.Split(line, " ")
-		for _, keyName := range keyNames {
+	for _, line := range strings.Split(keys, "\n") {
+		for _, keyName := range strings.Split(line, " ") {
 			if keyName != "" && keyName == key {
 				return true
 			}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 )
 
-var once sync.Once
-
 // Exec - Executes IPFS command.
 func Exec(args ...string) (hash string, err error) {
 	log.Printf("Exec: ipfs %s", strings.Join(args, " "))

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -77,7 +77,7 @@ func (sync *Synchronizer) watchForEvents() {
 			if err != nil {
 				log.Println("error:", err)
 			}
-			if sync.events != nil && sync.hash != hash {
+			if sync.events != nil && sync.hash != hash && hash != "" {
 				sync.events <- hash
 			}
 			if hash != "" {


### PR DESCRIPTION
This pull request provides a feature to publish new hash to IPNS every time there is a change in the hash of the directory. IPNS is slow procedure so if a hash is already being published to IPNS and there is a new hash available, the old IPNS publish process will be killed and a new IPNS publish process will start. 